### PR TITLE
[MHDP-19] Fixed search at location page finds exact match only

### DIFF
--- a/browser/filters.py
+++ b/browser/filters.py
@@ -173,6 +173,7 @@ class PersonFilter(filters.FilterSet):
 class LocationFilter(filters.FilterSet):
     last_updated = df.DateTimeFilter(name='last_updated', lookup_expr='gte',
                                      label='Last updated')
+    name = df.CharFilter(lookup_expr='icontains')
                                      
     o = df.OrderingFilter(
         # tuple-mapping retains order


### PR DESCRIPTION
To correct the issue, I modified the **LocationFilter**'s name attribute to lookup by **'icontains'**.